### PR TITLE
fix for GenericMeta across Python 3.6 and 3.7

### DIFF
--- a/pygfe/util.py
+++ b/pygfe/util.py
@@ -1,4 +1,8 @@
-from typing import GenericMeta
+try:
+    from typing import GenericMeta  # python 3.6
+except ImportError:
+    # in 3.7, genericmeta doesn't exist but we don't need it
+    class GenericMeta(type): pass
 from datetime import datetime, date
 from six import integer_types, iteritems
 


### PR DESCRIPTION
This is needed to allow the code to work in Docker (3.6) an interactively (3.7)