### PR TITLE
Support bulk runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -q \
     && apt-get clean
 
 RUN pip install --no-cache-dir seq-ann==1.1.0
-RUN pip install --no-cache-dir py-gfe==1.1.0
+RUN pip install --no-cache-dir py-gfe==1.1.1
 
 RUN touch blank.fasta \
     && seq2gfe -f blank.fasta -l HLA-A \

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import pandas as pd
 
 from Bio import SeqIO
 from BioSQL import BioSeqDatabase
@@ -84,20 +85,25 @@ def main():
     gfe_maker = gfe.GFE()
     start_time_rel = start_time_abs = time.time()
     n = 0
+    num_no_hit = 0
     for seq in SeqIO.parse(fastafile, "fasta"):
         try:
             if seq._seq and seq.description not in ids:
                 if not loc:
                     loc = get_locus(seq, kir=kir, verbose=verbose,
                                     refdata=seqann.refdata)
-
+                id, project, method, source, allele_index, allele_name = seq.description.split('|')
                 try:
-                    ann = seqann.annotate(seq, loc)
+                    ann = seqann.annotate(seq, loc, allele=allele_name)
                 except ValueError as e:
                     print("Skipping sequence: " + loc + " reason:", e)
                     break
+                if not ann:
+                    num_no_hit = num_no_hit + 1
+                    continue
 
-                features, gfe_name = gfe_maker.get_gfe(ann, loc)
+                # features, gfe_name = gfe_maker.get_gfe(ann, loc)
+                gfe_name = 'gfe_placeholder'
                 f_out.write('{} {:^20} {}\n'.format(id_spacer, str(seq.description), id_spacer))
                 l = 0
                 for f in ann.annotation:
@@ -105,16 +111,19 @@ def main():
                     f_out.write('\t'.join([gfe_name, f, ann.method, str(f_seq)]) + '\n')
                     l += len(f_seq)
                 f_out.write('\n')
-                if n and n > num_existing_ids and n % 1 == 0:
-                    print('%s rows loaded after %.2f seconds (with a length of %s)' %
-                            (n - num_existing_ids, time.time() - start_time_rel,
-                            len(seq)))
+                if n >= num_existing_ids and n % 1 == 0:
+                    print('%s rows loaded after %.2f seconds (with a length of %s).'
+                        ' Finished %s.'
+                        ' %s sec average per sequence. %s with no hits' %
+                            (n - num_existing_ids, time.time() - start_time_rel, len(seq),
+                            seq.description,
+                            (time.time() - start_time_abs) / (n + 1), num_no_hit))
                     start_time_rel = time.time()
                 n += 1
         except Exception as e:
             print("Error with %s at index %s: %s" % (seq.description, n, e))
     
-    print(i, "total rows loaded")
+    print(n, "total rows loaded")
 
     if serv:
         server.close()

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -134,12 +134,14 @@ def write_result(result):
     global start_time_abs
     global n
     f_out.write(result)
-    if not result:
+    if 'target_allele' not in result:
+        if 'clustalo' not in result:
+            print("Result did not use 'target_allele' or 'clustalo' methods.")
         num_no_hit = num_no_hit + 1
         return
     n += 1
     print('%s rows loaded.'
-        ' %s sec average per sequence. %s with no hits' %
+        ' %s sec average per sequence. %s with no allele hits' %
         (n, (time.time() - start_time_abs) / (n + 1), num_no_hit))
 
 def run_seqann(seq, loc, kir, verbose):#seq, loc, kir, verbose, seqann, f_out):

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -112,7 +112,7 @@ def main():
                     start_time_rel = time.time()
                 n += 1
         except Exception as e:
-            print("Error with %s at index %s: %s" % (seq.description, i, e))
+            print("Error with %s at index %s: %s" % (seq.description, n, e))
     
     print(i, "total rows loaded")
 

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -63,28 +63,32 @@ def main():
     seqann = BioSeqAnn(verbose=verbose, server=server, kir=kir)
 
     gfe_maker = gfe.GFE()
-    for seq in SeqIO.parse(fastafile, "fasta"):
-        if not loc:
-            loc = get_locus(seq, kir=kir, verbose=verbose,
-                            refdata=seqann.refdata)
-
+    for i, seq in enumerate(SeqIO.parse(fastafile, "fasta")):
         try:
-            ann = seqann.annotate(seq, loc)
-        except ValueError as e:
-            print("Skipping sequence: " + loc + " reason:", e)
-            break
+            if seq._seq:
+                if not loc:
+                    loc = get_locus(seq, kir=kir, verbose=verbose,
+                                    refdata=seqann.refdata)
 
-        features, gfe_name = gfe_maker.get_gfe(ann, loc)
-        print('{:*^20} {:^20} {:*^20}'.format("", str(seq.description), ""))
-        l = 0
-        for f in ann.annotation:
-            if isinstance(ann.annotation[f], DBSeq):
-                print(gfe_name, f, ann.method, str(ann.annotation[f]), sep="\t")
-                l += len(ann.annotation[f])
-            else:
-                print(gfe_name, f, ann.method, str(ann.annotation[f].seq), sep="\t")
-                l += len(ann.annotation[f].seq)
-        print("")
+                try:
+                    ann = seqann.annotate(seq, loc)
+                except ValueError as e:
+                    print("Skipping sequence: " + loc + " reason:", e)
+                    break
+
+                features, gfe_name = gfe_maker.get_gfe(ann, loc)
+                print('{:*^20} {:^20} {:*^20}'.format("", str(seq.description), ""))
+                l = 0
+                for f in ann.annotation:
+                    if isinstance(ann.annotation[f], DBSeq):
+                        print(gfe_name, f, ann.method, str(ann.annotation[f]), sep="\t")
+                        l += len(ann.annotation[f])
+                    else:
+                        print(gfe_name, f, ann.method, str(ann.annotation[f].seq), sep="\t")
+                        l += len(ann.annotation[f].seq)
+                print("")
+        except Exception as e:
+            print("Error with %s at index %s: %s" % (seq.description, i, e))
 
     if serv:
         server.close()

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -26,6 +26,11 @@ def main():
                         help="HLA locus",
                         type=str)
 
+    parser.add_argument("-o", "--output",
+                        required=True,
+                        help="Output file where GFE will be stored",
+                        type=str)    
+
     parser.add_argument("-k", "--kir",
                         required=False,
                         help="Bool for KIR",
@@ -45,6 +50,7 @@ def main():
     fastafile = args.file
     loc = args.locus
     serv = args.server
+    output_filename = args.output
 
     verbose = False
     if args.verbose:
@@ -62,10 +68,19 @@ def main():
 
     seqann = BioSeqAnn(verbose=verbose, server=server, kir=kir)
 
+    id_spacer = '{:*^20}'.format("")
+    f_out = open(output_filename, 'a+')
+    f_out.seek(0)
+    ids = []
+    for line in f_out:
+        if id_spacer in line:
+            spacer1, id, spacer2 = line.split(' ')
+            ids.append(id)
+
     gfe_maker = gfe.GFE()
     for i, seq in enumerate(SeqIO.parse(fastafile, "fasta")):
         try:
-            if seq._seq:
+            if seq._seq and seq.description not in ids:
                 if not loc:
                     loc = get_locus(seq, kir=kir, verbose=verbose,
                                     refdata=seqann.refdata)
@@ -77,16 +92,16 @@ def main():
                     break
 
                 features, gfe_name = gfe_maker.get_gfe(ann, loc)
-                print('{:*^20} {:^20} {:*^20}'.format("", str(seq.description), ""))
+                f_out.write('{} {:^20} {}\n'.format(id_spacer, str(seq.description), id_spacer))
                 l = 0
                 for f in ann.annotation:
                     if isinstance(ann.annotation[f], DBSeq):
-                        print(gfe_name, f, ann.method, str(ann.annotation[f]), sep="\t")
+                        f_out.write('\t'.join([gfe_name, f, ann.method, str(ann.annotation[f])]) + '\n')
                         l += len(ann.annotation[f])
                     else:
-                        print(gfe_name, f, ann.method, str(ann.annotation[f].seq), sep="\t")
+                        f_out.write('\t'.join([gfe_name, f, ann.method, str(ann.annotation[f].seq)]) + '\n')
                         l += len(ann.annotation[f].seq)
-                print("")
+                f_out.write('\n')
         except Exception as e:
             print("Error with %s at index %s: %s" % (seq.description, i, e))
 

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -8,6 +8,7 @@ from BioSQL import BioSeqDatabase
 from BioSQL.BioSeq import DBSeq
 from seqann import BioSeqAnn, gfe
 from seqann.blast_cmd import get_locus
+import time
 
 
 def main():
@@ -76,9 +77,14 @@ def main():
         if id_spacer in line:
             spacer1, id, spacer2 = line.split(' ')
             ids.append(id)
+    num_existing_ids = len(ids)
+    if num_existing_ids:
+        print(num_existing_ids, "rows in existing output")
 
     gfe_maker = gfe.GFE()
-    for i, seq in enumerate(SeqIO.parse(fastafile, "fasta")):
+    start_time_rel = start_time_abs = time.time()
+    n = 0
+    for seq in SeqIO.parse(fastafile, "fasta"):
         try:
             if seq._seq and seq.description not in ids:
                 if not loc:
@@ -95,12 +101,20 @@ def main():
                 f_out.write('{} {:^20} {}\n'.format(id_spacer, str(seq.description), id_spacer))
                 l = 0
                 for f in ann.annotation:
-                    seq = ann.annotation[f] if isinstance(ann.annotation[f], DBSeq) else ann.annotation[f].seq
-                    f_out.write('\t'.join([gfe_name, f, ann.method, str(seq)]) + '\n')
-                    l += len(seq)
+                    f_seq = ann.annotation[f] if isinstance(ann.annotation[f], DBSeq) else ann.annotation[f].seq
+                    f_out.write('\t'.join([gfe_name, f, ann.method, str(f_seq)]) + '\n')
+                    l += len(f_seq)
                 f_out.write('\n')
+                if n and n > num_existing_ids and n % 1 == 0:
+                    print('%s rows loaded after %.2f seconds (with a length of %s)' %
+                            (n - num_existing_ids, time.time() - start_time_rel,
+                            len(seq)))
+                    start_time_rel = time.time()
+                n += 1
         except Exception as e:
             print("Error with %s at index %s: %s" % (seq.description, i, e))
+    
+    print(i, "total rows loaded")
 
     if serv:
         server.close()

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -109,7 +109,7 @@ def main():
                 if 'homozygous' in allele_index.lower() and len(seq) % 2 == 0:
                     mid_point = int(len(seq)/2)
                     if str(seq[:mid_point]) == str(seq[mid_point:]):
-                        seq._seq = str(seq[:mid_point])
+                        seq = seq[:mid_point]
                 pool.apply_async(run_seqann,
                     args=(seq, loc, kir, verbose), #, seqann, f_out),
                     callback=write_result)
@@ -134,14 +134,12 @@ def write_result(result):
     global start_time_abs
     global n
     f_out.write(result)
-    if 'target_allele' not in result:
-        if 'clustalo' not in result:
-            print("Result did not use 'target_allele' or 'clustalo' methods.")
+    if not result:
         num_no_hit = num_no_hit + 1
         return
     n += 1
     print('%s rows loaded.'
-        ' %s sec average per sequence. %s with no allele hits' %
+        ' %s sec average per sequence. %s with no hits' %
         (n, (time.time() - start_time_abs) / (n + 1), num_no_hit))
 
 def run_seqann(seq, loc, kir, verbose):#seq, loc, kir, verbose, seqann, f_out):
@@ -152,7 +150,6 @@ def run_seqann(seq, loc, kir, verbose):#seq, loc, kir, verbose, seqann, f_out):
     id, project, method, source, allele_index, allele_name = seq.description.split('|')
     ann = seqann.annotate(seq, loc, allele=allele_name)
     if not ann:
-        print("No hit with", seq.description)
         return ''
 
     # features, gfe_name = gfe_maker.get_gfe(ann, loc)

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -74,33 +74,34 @@ def main():
                                               passwd="", host="localhost",
                                               db="bioseqdb")
 
-    pool = mp.Pool(1, initializer=init_seqann)
+    pool = mp.Pool(mp.cpu_count(), initializer=init_seqann)
     print("Finished initializing pool with %s processors." % mp.cpu_count())
-
-    id_spacer = '{:*^20}'.format("")
 
     global f_out
     f_out = open(output_filename, 'a+')
     f_out.seek(0)
-    ids = []
+    descriptions = set()
     for line in f_out:
-        if id_spacer in line:
-            spacer1, id, spacer2 = line.split(' ')
-            ids.append(id)
-    num_existing_ids = len(ids)
-    if num_existing_ids:
-        print(num_existing_ids, "rows in existing output")
-
-    f_out.write(','.join(['Description', 'GFE', 'Feature', 'Method', 'Sequence']) + '\n')
+        descriptions.add(line.split(',')[0])
+    num_existing_rows = len(descriptions)
+    if num_existing_rows:
+        print(num_existing_rows, "rows in existing output")
+    else:
+        f_out.write(','.join(['Description', 'GFE', 'Feature', 'Method', 'Sequence']) + '\n')
 
     gfe_maker = gfe.GFE()
     global start_time_abs
     start_time_abs = time.time()
 
     global n
+    parsed_existing_lines = False
     for seq in SeqIO.parse(fastafile, "fasta"):
         try:
-            if seq._seq and seq.description not in ids:
+            if seq.description in descriptions and not parsed_existing_lines:
+                continue
+            else:
+                parsed = True
+            if seq._seq and seq.description not in descriptions:
                 if not loc:
                     loc = get_locus(seq, kir=kir, verbose=verbose,
                                     refdata=seqann.refdata)
@@ -108,7 +109,7 @@ def main():
                 if 'homozygous' in allele_index.lower() and len(seq) % 2 == 0:
                     mid_point = int(len(seq)/2)
                     if str(seq[:mid_point]) == str(seq[mid_point:]):
-                        seq._seq = seq[:mid_point]
+                        seq._seq = str(seq[:mid_point])
                 pool.apply_async(run_seqann,
                     args=(seq, loc, kir, verbose), #, seqann, f_out),
                     callback=write_result)
@@ -124,8 +125,8 @@ def main():
 
 def init_seqann():
     global seqann
-    print("SeqAnn object initialized")
     seqann = BioSeqAnn()
+    print("SeqAnn object initialized")
 
 def write_result(result):
     global f_out

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -12,11 +12,8 @@ from seqann.blast_cmd import get_locus
 import time
 import multiprocessing as mp
 
-seqann = None
-f_out = None
-start_time_abs = None
-n = 0
-num_no_hit = 0
+start_time_abs = f_out = gfe_maker = seqann = None
+num_no_hit = n = 0
 
 def main():
     """This is run if file is directly executed, but not if imported as
@@ -73,9 +70,10 @@ def main():
         server = BioSeqDatabase.open_database(driver="pymysql", user="root",
                                               passwd="", host="localhost",
                                               db="bioseqdb")
-
-    pool = mp.Pool(mp.cpu_count(), initializer=init_seqann)
-    print("Finished initializing pool with %s processors." % mp.cpu_count())
+    cpu_count = mp.cpu_count() - 1
+    # cpu_count = 2
+    pool = mp.Pool(cpu_count, initializer=init_seqann)
+    print("Finished initializing pool with %s processors." % cpu_count)
 
     global f_out
     f_out = open(output_filename, 'a+')
@@ -89,7 +87,6 @@ def main():
     else:
         f_out.write(','.join(['Description', 'GFE', 'Feature', 'Method', 'Sequence']) + '\n')
 
-    gfe_maker = gfe.GFE()
     global start_time_abs
     start_time_abs = time.time()
 
@@ -102,10 +99,11 @@ def main():
             else:
                 parsed = True
             if seq._seq and seq.description not in descriptions:
-                if not loc:
-                    loc = get_locus(seq, kir=kir, verbose=verbose,
-                                    refdata=seqann.refdata)
+                # if not loc:
+                #     loc = get_locus(seq, kir=kir, verbose=verbose,
+                #                     refdata=seqann.refdata)
                 id, project, method, source, allele_index, allele_name = seq.description.split('|')
+                # id, allele_index, allele_name = seq.description.split('|')
                 if 'homozygous' in allele_index.lower() and len(seq) % 2 == 0:
                     mid_point = int(len(seq)/2)
                     if str(seq[:mid_point]) == str(seq[mid_point:]):
@@ -125,42 +123,54 @@ def main():
 
 def init_seqann():
     global seqann
+    global gfe_maker
+    global start_time_abs
+    global i
     seqann = BioSeqAnn()
+    gfe_maker = gfe.GFE()
+    start_time_abs = time.time()
+    i = 0
     print("SeqAnn object initialized")
 
 def write_result(result):
-    global f_out
     global num_no_hit
     global start_time_abs
     global n
-    f_out.write(result)
-    if not result:
-        num_no_hit = num_no_hit + 1
-        return
-    n += 1
-    print('%s rows loaded.'
-        ' %s sec average per sequence. %s with no hits' %
-        (n, (time.time() - start_time_abs) / (n + 1), num_no_hit))
+    global f_out
+    if result:
+        n += 1
+        f_out.write(result)
+    else:
+        num_no_hit += 1
+    # global start_time_abs
+    # global i
+    # print('' % ((time.time() - start_time_abs) / (i + 1)))
+    # i = i + 1
+    print('%s rows loaded. %s with no hits. %s seconds average per sequence.' 
+            % (n, num_no_hit, ((time.time() - start_time_abs) / (n + num_no_hit + 1))))
 
 def run_seqann(seq, loc, kir, verbose):#seq, loc, kir, verbose, seqann, f_out):
     global seqann
+    global gfe_maker
     if not loc:
         loc = get_locus(seq, kir=kir, verbose=verbose,
                         refdata=seqann.refdata)
     id, project, method, source, allele_index, allele_name = seq.description.split('|')
+    # id, allele_index, allele_name = seq.description.split('|')
+
     ann = seqann.annotate(seq, loc, allele=allele_name)
     if not ann:
+        print('No results with', seq.description)
         return ''
-
-    # features, gfe_name = gfe_maker.get_gfe(ann, loc)
-    gfe_name = 'gfe_placeholder'
+    features, gfe_name = gfe_maker.get_gfe(ann, loc)
+    # gfe_name = 'gfe_placeholder'
     l = 0
     output = ''
-    for f in ann.annotation:
-        f_seq = ann.annotation[f] if isinstance(ann.annotation[f], DBSeq) else ann.annotation[f].seq
-        output += ','.join([str(seq.description), gfe_name, f, ann.method, str(f_seq)]) + '\n'
-        l += len(f_seq)
-    # f_out.write(output)
+    if ann:
+        for f in ann.annotation:
+            f_seq = ann.annotation[f] if isinstance(ann.annotation[f], DBSeq) else ann.annotation[f].seq
+            output += ','.join([str(seq.description), gfe_name, f, ann.method, str(f_seq)]) + '\n'
+            l += len(f_seq)
     return output
 
 if __name__ == '__main__':

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -10,7 +10,13 @@ from BioSQL.BioSeq import DBSeq
 from seqann import BioSeqAnn, gfe
 from seqann.blast_cmd import get_locus
 import time
+import multiprocessing as mp
 
+seqann = None
+f_out = None
+start_time_abs = None
+n = 0
+num_no_hit = 0
 
 def main():
     """This is run if file is directly executed, but not if imported as
@@ -68,9 +74,12 @@ def main():
                                               passwd="", host="localhost",
                                               db="bioseqdb")
 
-    seqann = BioSeqAnn(verbose=verbose, server=server, kir=kir)
+    pool = mp.Pool(mp.cpu_count(), initializer=init_seqann)
+    print("Finished initialized pool with %s processers" % mp.cpu_count())
 
     id_spacer = '{:*^20}'.format("")
+
+    global f_out
     f_out = open(output_filename, 'a+')
     f_out.seek(0)
     ids = []
@@ -85,9 +94,10 @@ def main():
     f_out.write(','.join(['Description', 'GFE', 'Feature', 'Method', 'Sequence']) + '\n')
 
     gfe_maker = gfe.GFE()
+    global start_time_abs
     start_time_rel = start_time_abs = time.time()
-    n = 0
-    num_no_hit = 0
+
+    global n
     for seq in SeqIO.parse(fastafile, "fasta"):
         try:
             if seq._seq and seq.description not in ids:
@@ -95,39 +105,58 @@ def main():
                     loc = get_locus(seq, kir=kir, verbose=verbose,
                                     refdata=seqann.refdata)
                 id, project, method, source, allele_index, allele_name = seq.description.split('|')
-                try:
-                    ann = seqann.annotate(seq, loc, allele=allele_name)
-                except ValueError as e:
-                    print("Skipping sequence: " + loc + " reason:", e)
-                    break
-                if not ann:
-                    num_no_hit = num_no_hit + 1
-                    continue
-
-                # features, gfe_name = gfe_maker.get_gfe(ann, loc)
-                gfe_name = 'gfe_placeholder'
-                l = 0
-                for f in ann.annotation:
-                    f_seq = ann.annotation[f] if isinstance(ann.annotation[f], DBSeq) else ann.annotation[f].seq
-                    f_out.write(','.join([str(seq.description), gfe_name, f, ann.method, str(f_seq)]) + '\n')
-                    l += len(f_seq)
-                if n >= num_existing_ids and n % 1 == 0:
-                    print('%s rows loaded after %.2f seconds (with a length of %s).'
-                        ' Finished %s.'
-                        ' %s sec average per sequence. %s with no hits' %
-                            (n - num_existing_ids, time.time() - start_time_rel, len(seq),
-                            seq.description,
-                            (time.time() - start_time_abs) / (n + 1), num_no_hit))
-                    start_time_rel = time.time()
-                n += 1
+            
+                pool.apply_async(run_seqann,
+                    args=(seq, loc, kir, verbose), #, seqann, f_out),
+                    callback=write_result)
         except Exception as e:
             print("Error with %s at index %s: %s" % (seq.description, n, e))
     
+    pool.close()
+    pool.join()
     print("%s total rows loaded after %.2f seconds" % (n, time.time() - start_time_abs))
 
     if serv:
         server.close()
 
+def init_seqann():
+    global seqann
+    seqann = BioSeqAnn()
+
+def write_result(result):
+    global f_out
+    global num_no_hit
+    global start_time_abs
+    global n
+    f_out.write(result)
+    if not result:
+        num_no_hit = num_no_hit + 1
+        return
+    n += 1
+    print('%s rows loaded.'
+        ' %s sec average per sequence. %s with no hits' %
+        (n, (time.time() - start_time_abs) / (n + 1), num_no_hit))
+
+def run_seqann(seq, loc, kir, verbose):#seq, loc, kir, verbose, seqann, f_out):
+    global seqann
+    if not loc:
+        loc = get_locus(seq, kir=kir, verbose=verbose,
+                        refdata=seqann.refdata)
+    id, project, method, source, allele_index, allele_name = seq.description.split('|')
+    ann = seqann.annotate(seq, loc, allele=allele_name)
+    if not ann:
+        return ''
+
+    # features, gfe_name = gfe_maker.get_gfe(ann, loc)
+    gfe_name = 'gfe_placeholder'
+    l = 0
+    output = ''
+    for f in ann.annotation:
+        f_seq = ann.annotation[f] if isinstance(ann.annotation[f], DBSeq) else ann.annotation[f].seq
+        output += ','.join([str(seq.description), gfe_name, f, ann.method, str(f_seq)]) + '\n'
+        l += len(f_seq)
+    # f_out.write(output)
+    return output
 
 if __name__ == '__main__':
     """The following will be run if file is executed directly,

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -95,12 +95,9 @@ def main():
                 f_out.write('{} {:^20} {}\n'.format(id_spacer, str(seq.description), id_spacer))
                 l = 0
                 for f in ann.annotation:
-                    if isinstance(ann.annotation[f], DBSeq):
-                        f_out.write('\t'.join([gfe_name, f, ann.method, str(ann.annotation[f])]) + '\n')
-                        l += len(ann.annotation[f])
-                    else:
-                        f_out.write('\t'.join([gfe_name, f, ann.method, str(ann.annotation[f].seq)]) + '\n')
-                        l += len(ann.annotation[f].seq)
+                    seq = ann.annotation[f] if isinstance(ann.annotation[f], DBSeq) else ann.annotation[f].seq
+                    f_out.write('\t'.join([gfe_name, f, ann.method, str(seq)]) + '\n')
+                    l += len(seq)
                 f_out.write('\n')
         except Exception as e:
             print("Error with %s at index %s: %s" % (seq.description, i, e))

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -123,7 +123,7 @@ def main():
         except Exception as e:
             print("Error with %s at index %s: %s" % (seq.description, n, e))
     
-    print(n, "total rows loaded")
+    print("%s total rows loaded after %.2f seconds" % (n, time.time() - start_time_abs))
 
     if serv:
         server.close()

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -82,6 +82,8 @@ def main():
     if num_existing_ids:
         print(num_existing_ids, "rows in existing output")
 
+    f_out.write(','.join(['Description', 'GFE', 'Feature', 'Method', 'Sequence']) + '\n')
+
     gfe_maker = gfe.GFE()
     start_time_rel = start_time_abs = time.time()
     n = 0
@@ -104,13 +106,11 @@ def main():
 
                 # features, gfe_name = gfe_maker.get_gfe(ann, loc)
                 gfe_name = 'gfe_placeholder'
-                f_out.write('{} {:^20} {}\n'.format(id_spacer, str(seq.description), id_spacer))
                 l = 0
                 for f in ann.annotation:
                     f_seq = ann.annotation[f] if isinstance(ann.annotation[f], DBSeq) else ann.annotation[f].seq
-                    f_out.write('\t'.join([gfe_name, f, ann.method, str(f_seq)]) + '\n')
+                    f_out.write(','.join([str(seq.description), gfe_name, f, ann.method, str(f_seq)]) + '\n')
                     l += len(f_seq)
-                f_out.write('\n')
                 if n >= num_existing_ids and n % 1 == 0:
                     print('%s rows loaded after %.2f seconds (with a length of %s).'
                         ' Finished %s.'

--- a/scripts/seq2gfe
+++ b/scripts/seq2gfe
@@ -74,8 +74,8 @@ def main():
                                               passwd="", host="localhost",
                                               db="bioseqdb")
 
-    pool = mp.Pool(mp.cpu_count(), initializer=init_seqann)
-    print("Finished initialized pool with %s processers" % mp.cpu_count())
+    pool = mp.Pool(1, initializer=init_seqann)
+    print("Finished initializing pool with %s processors." % mp.cpu_count())
 
     id_spacer = '{:*^20}'.format("")
 
@@ -95,7 +95,7 @@ def main():
 
     gfe_maker = gfe.GFE()
     global start_time_abs
-    start_time_rel = start_time_abs = time.time()
+    start_time_abs = time.time()
 
     global n
     for seq in SeqIO.parse(fastafile, "fasta"):
@@ -105,7 +105,10 @@ def main():
                     loc = get_locus(seq, kir=kir, verbose=verbose,
                                     refdata=seqann.refdata)
                 id, project, method, source, allele_index, allele_name = seq.description.split('|')
-            
+                if 'homozygous' in allele_index.lower() and len(seq) % 2 == 0:
+                    mid_point = int(len(seq)/2)
+                    if str(seq[:mid_point]) == str(seq[mid_point:]):
+                        seq._seq = seq[:mid_point]
                 pool.apply_async(run_seqann,
                     args=(seq, loc, kir, verbose), #, seqann, f_out),
                     callback=write_result)
@@ -121,6 +124,7 @@ def main():
 
 def init_seqann():
     global seqann
+    print("SeqAnn object initialized")
     seqann = BioSeqAnn()
 
 def write_result(result):
@@ -145,6 +149,7 @@ def run_seqann(seq, loc, kir, verbose):#seq, loc, kir, verbose, seqann, f_out):
     id, project, method, source, allele_index, allele_name = seq.description.split('|')
     ann = seqann.annotate(seq, loc, allele=allele_name)
     if not ann:
+        print("No hit with", seq.description)
         return ''
 
     # features, gfe_name = gfe_maker.get_gfe(ann, loc)

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from time import time
+
+# Prepare data
+np.random.RandomState(100)
+arr = np.random.randint(0, 10, size=[200000, 5])
+data = arr.tolist()
+data[:5]
+
+# Parallel processing with Pool.apply_async()
+
+import multiprocessing as mp
+pool = mp.Pool(mp.cpu_count())
+
+results = []
+
+# Step 1: Redefine, to accept `i`, the iteration number
+def howmany_within_range2(i, row, minimum, maximum):
+    """Returns how many numbers lie within `maximum` and `minimum` in a given `row`"""
+    count = 0
+    for n in row:
+        if minimum <= n <= maximum:
+            count = count + 1
+    return (i, count)
+
+
+# Step 2: Define callback function to collect the output in `results`
+def collect_result(result):
+    global results
+    results.append(result)
+
+
+# Step 3: Use loop to parallelize
+for i, row in enumerate(data):
+    pool.apply_async(howmany_within_range2, args=(i, row, 4, 8), callback=collect_result)
+
+# Step 4: Close Pool and let all the processes complete    
+pool.close()
+pool.join()  # postpones the execution of next line of code until all processes in the queue are done.
+
+# Step 5: Sort results [OPTIONAL]
+results.sort(key=lambda x: x[0])
+results_final = [r for i, r in results]
+
+print(results_final[:10])
+#> [3, 1, 4, 4, 4, 2, 1, 1, 3, 3]

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ test_requirements = [
 
 setup(
     name='py-gfe',
-    version='1.1.0',
+    version='1.1.1',
     description="Python package for converting sequence annotations to gene feature enumerations (GFE).",
     long_description=readme + '\n\n' + history,
     author="CIBMTR",


### PR DESCRIPTION
Change the output to be more like a .csv file with necessary information in every row, instead of a .txt with a header and data lines underneath that rely on the header. Much easier to load into the workspace for further development (for instance, when using `pandas`).

This also adds multiprocessing and a try/catch loop for bulk runs. It also detects if an existing output file has data results that can be skipped, based on the header.